### PR TITLE
fix some examples after module renaming 7a8e0bf

### DIFF
--- a/examples/basic_mouse_loc/main.ml
+++ b/examples/basic_mouse_loc/main.ml
@@ -31,13 +31,13 @@ let%sync m =
 
 let () =
   let open Pendulum in
-  let open Machine in
+  let open Signal in
   let open Graphics in
   Graphics.open_graph " 300x300";
 
-  let (set_btn_up,
+  let set_btn_up,
        set_move,
-       set_ex),
+       set_ex,
       step_m = m ((), Graphics.mouse_pos (), ())
   in
   while true do

--- a/examples/odd_even/main.ml
+++ b/examples/odd_even/main.ml
@@ -32,8 +32,8 @@ let%sync m2 =
   end
 
 let () =
-  let open Pendulum.Machine in
-  let (set_a, set_b), step = m (0, "") in
+  let open Pendulum.Signal in
+  let set_a, set_b, step = m (0, "") in
   for i = 1 to 10 do
     set_a i;
     ignore (step ());
@@ -42,7 +42,7 @@ let () =
 let () = Format.printf "@."
 
 let () =
-  let open Pendulum.Machine in
+  let open Pendulum.Signal in
   let set_a, step = m2 () in
   for i = 0 to 9 do
     if i mod 3 = 0 then set_a ();

--- a/examples/with_ocsigen/todomvc.ml
+++ b/examples/with_ocsigen/todomvc.ml
@@ -130,7 +130,7 @@ module Model = struct
           cntmax := max !cntmax k;
           add_item k @@ create_item k (Js.string str) sel;
         ) @@ List.sort (fun (k1, _, _) (k2, _, _) -> compare k1 k2) l;
-      Pendulum.Machine.setval cnt !cntmax;
+      Pendulum.Signal.setval cnt !cntmax;
       !cntleft
 
 
@@ -168,14 +168,14 @@ module View = struct
     let open Html5 in
     let open Pendulum in
     let lbl_content = label ~a:[a_ondblclick (fun evt ->
-        Machine.set_present_value dblclick_sig cnt; animate (); true)]
+        Signal.set_present_value dblclick_sig cnt; animate (); true)]
         [pcdata @@ Js.to_string (str##trim)]
     in
     let btn_rm = button ~a:[a_class ["destroy"]; a_onclick (fun evt ->
-        Machine.set_present_value delete_sig cnt; animate (); true)] []
+        Signal.set_present_value delete_sig cnt; animate (); true)] []
     in
     let keyhandler ev =
-      Machine.set_present_value keydown_sig (cnt, ev##.keyCode);
+      Signal.set_present_value keydown_sig (cnt, ev##.keyCode);
       animate (); true
     in
     let txt = Js.to_string @@ str##trim in
@@ -183,7 +183,7 @@ module View = struct
         a_input_type `Text; a_class ["edit"];
         a_value txt;
         a_id (Format.sprintf "it-edit-%d" cnt);
-        a_onblur (fun _ -> Machine.set_present_value blur_sig cnt;
+        a_onblur (fun _ -> Signal.set_present_value blur_sig cnt;
                    animate (); true);
         a_onkeydown keyhandler; a_onkeypress keyhandler
       ] ()
@@ -192,7 +192,7 @@ module View = struct
       let a = [
         a_input_type `Checkbox; a_class ["toggle"];
         a_onclick (fun _ ->
-            Pendulum.Machine.set_present_value select_sig cnt; animate (); true)
+            Pendulum.Signal.set_present_value select_sig cnt; animate (); true)
       ] in
       let a = if selected then (a_checked `Checked) :: a else a
       in input ~a ()
@@ -210,7 +210,7 @@ module View = struct
 
   let create_items cnt tasks animate items_ul delete_sig blur_sig
       dblclick_sig keydown_sig select_sig strs selected =
-    let open Pendulum.Machine in
+    let open Pendulum.Signal in
     let nb = List.fold_left (fun acc str ->
         let cnt = cnt.value + acc + 1 in
         let it = create_item animate delete_sig blur_sig dblclick_sig
@@ -218,7 +218,7 @@ module View = struct
         in add_append tasks items_ul cnt it; acc + 1
       ) 0 strs
     in
-    Pendulum.Machine.set_present_value cnt (!!cnt + nb);
+    Pendulum.Signal.set_present_value cnt (!!cnt + nb);
     nb
 
 


### PR DESCRIPTION
basic_mouse_loc, odd_even and with_oxygen did not compile because they refered to Pendulum.Machine